### PR TITLE
make sure response is defined.

### DIFF
--- a/disqus.js
+++ b/disqus.js
@@ -54,7 +54,7 @@ Disqus.prototype = {
     },
 
     _handleResponse : function(error, response, body, callback) {
-        if (response.statusCode === 200) {
+        if (response && response.statusCode === 200) {
             return body;
         } else {
             return {


### PR DESCRIPTION
fixes this error:

```
 if (response.statusCode === 200) {
                    ^
TypeError: Cannot read property 'statusCode' of undefined
```
